### PR TITLE
java.math.BigDecimal and java.io.File typed Map should not be added to the ref list

### DIFF
--- a/HessianClasses/CWHessianArchiver+Private.h
+++ b/HessianClasses/CWHessianArchiver+Private.h
@@ -92,7 +92,7 @@
 -(NSData*)readDataWithTag:(char)tag;
 -(NSException*)readFault;
 -(NSArray*)readList;
--(id)readMapWithTypedObject:(id)typedObject;
+-(id)readMapWithTypedObject:(id)typedObject asRef:(BOOL)asRef;
 -(id)readMap;
 -(CWDistantHessianObject*)readRemote;
 

--- a/HessianClasses/CWHessianUnarchiver+Private.m
+++ b/HessianClasses/CWHessianUnarchiver+Private.m
@@ -277,13 +277,15 @@
   return list;
 }
 
--(id)readMapWithTypedObject:(id)typedObject;
+-(id)readMapWithTypedObject:(id)typedObject asRef:(BOOL)asRef;
 {
   NSMutableDictionary* map = [NSMutableDictionary dictionary];
-  if (typedObject) {
-    [self.objectReferences addObject:typedObject];
-  } else {
-    [self.objectReferences addObject:map];
+  if (asRef) {
+    if (typedObject) {
+      [self.objectReferences addObject:typedObject];
+    } else {
+      [self.objectReferences addObject:map];
+    }
   }
   while ([self peekChar] != 'z') {
     NSObject* key = [self readTypedObject];
@@ -309,10 +311,12 @@
 {
   NSString* className = nil;
   id typedObject = nil;
+  BOOL asRef = YES;
   if ([self peekChar] == 't') {
     [self readChar];
     className = [self readStringWithTag:'S'];
     if ([className length] > 0) {
+      asRef = !([className isEqualToString:@"java.math.BigDecimal"] || [className isEqualToString:@"java.io.File"]);
       Class typedClass = [self classForClassName:className];
       if (typedClass) {
         typedObject = class_createInstance(typedClass, 0);
@@ -327,7 +331,7 @@
       }
     }
   }
-  return [self readMapWithTypedObject:typedObject];
+  return [self readMapWithTypedObject:typedObject asRef:asRef];
 }
 
 -(CWDistantHessianObject*)readRemote;


### PR DESCRIPTION
Indeed, on the Java side, they are serialized with `com.caucho.hessian.io.StringValueSerializer`, this special Map serializer do not call `AbstractHessianOutput.addRef()`, nor we should on the `HessianKit` side.

_WARNING: I did not run the unit test to validate this PR is valid_
